### PR TITLE
feat: configurable api hostname

### DIFF
--- a/RDNET/Apis/Authentication.cs
+++ b/RDNET/Apis/Authentication.cs
@@ -86,7 +86,7 @@ public class AuthenticationApi : IAuthenticationApi
     {
         var redirectUriEncoded = HttpUtility.UrlEncode(redirectUri.OriginalString);
 
-        return $"{Store.AuthUrl}auth?client_id={_store.AppId}&redirect_uri={redirectUriEncoded}&response_type=code&state={state}";
+        return $"{_store.AuthUrl}auth?client_id={_store.AppId}&redirect_uri={redirectUriEncoded}&response_type=code&state={state}";
     }
 
     /// <inheritdoc />

--- a/RDNET/Apis/Requests.cs
+++ b/RDNET/Apis/Requests.cs
@@ -126,14 +126,14 @@ internal class Requests(HttpClient httpClient, Store store)
     public async Task<T> GetAuthRequestAsync<T>(String url, CancellationToken cancellationToken)
         where T : class, new()
     {
-        return await Request<T>(Store.AuthUrl, url, false, RequestType.Get, null, cancellationToken);
+        return await Request<T>(store.AuthUrl, url, false, RequestType.Get, null, cancellationToken);
     }
 
     public async Task<T> PostAuthRequestAsync<T>(String url, IEnumerable<KeyValuePair<String, String?>> data, CancellationToken cancellationToken)
         where T : class, new()
     {
         var content = new FormUrlEncodedContent(data);
-        return await Request<T>(Store.AuthUrl, url, false, RequestType.Post, content, cancellationToken);
+        return await Request<T>(store.AuthUrl, url, false, RequestType.Post, content, cancellationToken);
     }
 
     public async Task<String?> GetRequestHeaderAsync(String url,
@@ -141,14 +141,14 @@ internal class Requests(HttpClient httpClient, Store store)
                                                      Boolean requireAuthentication,
                                                      CancellationToken cancellationToken)
     {
-        var (_, headerValue) = await Request(Store.ApiUrl, url, header, requireAuthentication, RequestType.Get, null, cancellationToken);
+        var (_, headerValue) = await Request(store.ApiUrl, url, header, requireAuthentication, RequestType.Get, null, cancellationToken);
 
         return headerValue;
     }
 
     public async Task<String?> GetRequestAsync(String url, Boolean requireAuthentication, CancellationToken cancellationToken)
     {
-        var (text, _) = await Request(Store.ApiUrl, url, null, requireAuthentication, RequestType.Get, null, cancellationToken);
+        var (text, _) = await Request(store.ApiUrl, url, null, requireAuthentication, RequestType.Get, null, cancellationToken);
 
         return text;
     }
@@ -156,38 +156,38 @@ internal class Requests(HttpClient httpClient, Store store)
     public async Task<T> GetRequestAsync<T>(String url, Boolean requireAuthentication, CancellationToken cancellationToken)
         where T : class, new()
     {
-        return await Request<T>(Store.ApiUrl, url, requireAuthentication, RequestType.Get, null, cancellationToken);
+        return await Request<T>(store.ApiUrl, url, requireAuthentication, RequestType.Get, null, cancellationToken);
     }
 
     public async Task PostRequestAsync(String url, IEnumerable<KeyValuePair<String, String?>>? data, Boolean requireAuthentication, CancellationToken cancellationToken)
     {
         var content = data != null ? new FormUrlEncodedContent(data) : null;
-        await Request(Store.ApiUrl, url, null, requireAuthentication, RequestType.Post, content, cancellationToken);
+        await Request(store.ApiUrl, url, null, requireAuthentication, RequestType.Post, content, cancellationToken);
     }
 
     public async Task<T> PostRequestAsync<T>(String url, IEnumerable<KeyValuePair<String, String?>>? data, Boolean requireAuthentication, CancellationToken cancellationToken)
         where T : class, new()
     {
         var content = data != null ? new FormUrlEncodedContent(data) : null;
-        return await Request<T>(Store.ApiUrl, url, requireAuthentication, RequestType.Post, content, cancellationToken);
+        return await Request<T>(store.ApiUrl, url, requireAuthentication, RequestType.Post, content, cancellationToken);
     }
 
     public async Task PutRequestAsync(String url, Byte[] file, Boolean requireAuthentication, CancellationToken cancellationToken)
     {
         var content = new ByteArrayContent(file);
-        await Request(Store.ApiUrl, url, null, requireAuthentication, RequestType.Put, content, cancellationToken);
+        await Request(store.ApiUrl, url, null, requireAuthentication, RequestType.Put, content, cancellationToken);
     }
 
     public async Task<T> PutRequestAsync<T>(String url, Byte[] file, Boolean requireAuthentication, CancellationToken cancellationToken)
         where T : class, new()
     {
         var content = new ByteArrayContent(file);
-        return await Request<T>(Store.ApiUrl, url, requireAuthentication, RequestType.Put, content, cancellationToken);
+        return await Request<T>(store.ApiUrl, url, requireAuthentication, RequestType.Put, content, cancellationToken);
     }
 
     public async Task DeleteRequestAsync(String url, Boolean requireAuthentication, CancellationToken cancellationToken)
     {
-        await Request(Store.ApiUrl, url, null, requireAuthentication, RequestType.Delete, null, cancellationToken);
+        await Request(store.ApiUrl, url, null, requireAuthentication, RequestType.Delete, null, cancellationToken);
     }
 
     private enum RequestType

--- a/RDNET/Apis/Store.cs
+++ b/RDNET/Apis/Store.cs
@@ -2,8 +2,9 @@
 
 internal class Store
 {
-    public const String AuthUrl = "https://api.real-debrid.com/oauth/v2/";
-    public const String ApiUrl = "https://api.real-debrid.com/rest/1.0/";
+    public String ApiHostname { get; set; } = "api.real-debrid.com";
+    public String AuthUrl => $"https://{ApiHostname}/oauth/v2/";
+    public String ApiUrl => $"https://{ApiHostname}/rest/1.0/";
 
     public String? AppId;
     public Int32 RetryCount { get; set; }

--- a/RDNET/RdNetClient.cs
+++ b/RDNET/RdNetClient.cs
@@ -70,7 +70,7 @@ public class RdNetClient : IRdNetClient
     public ITrafficApi Traffic { get; }
     public IUnrestrictApi Unrestrict { get; }
     public IUserApi User { get; }
-        
+
     /// <summary>
     ///     Initialize the RdNet API.
     ///     To use authentication make sure to call either UseApiAuthentication for Api Key authentication
@@ -86,10 +86,19 @@ public class RdNetClient : IRdNetClient
     /// <param name="retryCount">
     ///     The API will retry this many times before failing.
     /// </param>
-    public RdNetClient(String? appId = null, HttpClient? httpClient = null, Int32 retryCount = 1)
+    /// <param name="apiHostname">
+    ///     Optional alternate hostname to use for the api base.
+    ///     Useful if the normal hostname <c>api.real-debrid.com</c> is blocked in your region
+    /// </param>
+    public RdNetClient(String? appId = null, HttpClient? httpClient = null, Int32 retryCount = 1, String? apiHostname = null)
     {
         _store.AppId= appId ?? "X245A4XAIBGVM";
         _store.RetryCount = retryCount;
+
+        if (apiHostname != null)
+        {
+            _store.ApiHostname = apiHostname;
+        }
 
         var client = httpClient ?? new HttpClient();
 


### PR DESCRIPTION
closes #5

adds additional constructor argument `apiHostname` to change the hostname used to construct the api base url.
This lets users in countries that have blocked the main api url `https://api.real-debrid.com` but not the alternate mirrors like `https://api-0.real-debrid.com` to use the api.

related rogerfar/rdt-client#727